### PR TITLE
feat: Added Api Key Convention Plugin

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,9 +9,12 @@ _______________________________________________
 
 ## <sup><sup>&#x1F534; [Mandatory]</sup></sup> What's the change?
 -   
+
 ## <sup><sup>&#x1F534; [Mandatory]</sup></sup> Why do we need this change?
 -   
+
 ## Related issues/PRs/Jira ticket links
 -   
+
 ## <sup><sup>&#x1F534; [Mandatory if it's UI related]</sup></sup> Screenshots
 -

--- a/README.md
+++ b/README.md
@@ -3,3 +3,16 @@
 Doodling around
 
 Trying to apply best practices for later usages :)
+
+
+### How to run the app
+
+In order to run the app, you need to create a `local.properties` file in the root folder of the project.
+Here is how my current `local.properties` looks like:
+
+```
+sdk.dir=/Users/eky/Library/Android/sdk
+
+doodle.api.url="https://api.jikan.moe/v4/"
+doodle.api.key="sample api key" #Jikan API doesn't require an API key, but I'm using it as an example
+```

--- a/app/src/main/java/dev/enesky/doodle/core/network/di/NetworkModule.kt
+++ b/app/src/main/java/dev/enesky/doodle/core/network/di/NetworkModule.kt
@@ -25,7 +25,7 @@ val networkModule = module {
     single<Retrofit> {
         Retrofit.Builder()
             .client(get<OkHttpClient>())
-            .baseUrl(BuildConfig.BASE_URL)
+            .baseUrl(BuildConfig.DOODLE_API_URL)
             .addConverterFactory(GsonConverterFactory.create())
             .build()
     }

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -24,6 +24,18 @@ dependencies {
     enableVersionCatalogAccess()
 }
 
+/**
+ * Little note about convention plugin id naming
+ *
+ * ID's should be UNIQUE
+ * If a id starts with something like this -> doodle.android.application
+ * And there is a different id like this -> doodle.android.application.compose
+ * First one will give you troubles when you try to use it
+ * Because it may recognized as the second one and it can throw an error
+ * Try to use unique id's like -> doodle.android.application.main instead of doodle.android.application
+ *
+ **/
+
 gradlePlugin {
     plugins {
         register("androidApplication") {
@@ -69,6 +81,10 @@ gradlePlugin {
         register("detekt") {
             id = libs.plugins.doodle.detekt.library.get().pluginId
             implementationClass = "DetektConventionPlugin"
+        }
+        register("apiKeyProvider") {
+            id = libs.plugins.doodle.api.key.provider.get().pluginId
+            implementationClass = "ApiKeyProviderConventionPlugin"
         }
     }
 }

--- a/build-logic/convention/src/main/kotlin/AndroidSigningConfigConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidSigningConfigConventionPlugin.kt
@@ -1,6 +1,7 @@
 
 import com.android.build.gradle.internal.dsl.BaseAppModuleExtension
 import dev.enesky.build_logic.convention.createSigningConfigFromProperties
+import dev.enesky.build_logic.convention.libs
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
@@ -12,6 +13,9 @@ import java.util.Properties
  */
 class AndroidSigningConfigConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) = with(target) {
+
+        pluginManager.apply(libs.plugins.doodle.api.key.provider.get().pluginId)
+
         val keystoreProperties = Properties()
         val keystorePath = "../Doodle/keystore/keystore.properties"
         val keystorePropertiesFile = rootProject.file(keystorePath)

--- a/build-logic/convention/src/main/kotlin/ApiKeyProviderConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/ApiKeyProviderConventionPlugin.kt
@@ -14,16 +14,35 @@ class ApiKeyProviderConventionPlugin : Plugin<Project> {
             }
         }
 
-        val doodleApiUrl = checkNotNull(
-            localProperties.getProperty("doodle.apiurl") ?: System.getenv("DOODLE_API_URL")
+        val doodleApiUrl: String = checkNotNull(
+            localProperties.getProperty("doodle.api.url") ?: System.getenv("DOODLE_API_URL")
         )
-        val doodleApiKey = checkNotNull(
-            localProperties.getProperty("doodle.apikey") ?: System.getenv("DOODLE_API_KEY")
+        val doodleApiKey: String = checkNotNull(
+            localProperties.getProperty("doodle.api.key") ?: System.getenv("DOODLE_API_KEY")
         )
 
         extensions.configure<BaseAppModuleExtension> {
-            defaultConfig.buildConfigField("String", "DOODLE_API_URL", "\"$doodleApiUrl\"")
-            defaultConfig.buildConfigField("String", "DOODLE_API_KEY", "\"$doodleApiKey\"")
+            defaultConfig.buildConfigField("String", "DOODLE_API_URL", doodleApiUrl)
+            defaultConfig.buildConfigField("String", "DOODLE_API_KEY", doodleApiKey)
+
+            /**
+             * Example usage of buildConfigField for different build types and flavors
+             *
+             * buildTypes {
+             *     getByName("release") {
+             *         buildConfigField("String", "DOODLE_API_URL", doodleApiUrlForRelease)
+             *         buildConfigField("String", "DOODLE_API_KEY", doodleApiKeyForRelease)
+             *     }
+             * }
+             *
+             * productFlavors {
+             *     getByName("premium") {
+             *         buildConfigField("String", "DOODLE_API_URL", doodleApiUrlForPremium)
+             *         buildConfigField("String", "DOODLE_API_KEY", doodleApiKeyForPremium)
+             *     }
+             * }
+             */
+
         }
     }
 }

--- a/build-logic/convention/src/main/kotlin/ApiKeyProviderConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/ApiKeyProviderConventionPlugin.kt
@@ -4,6 +4,10 @@ import org.gradle.api.Project
 import org.gradle.kotlin.dsl.configure
 import java.util.Properties
 
+/**
+ * Configure Api Key Provider
+ * -> Only for app/build.gradle.kts <-
+ */
 class ApiKeyProviderConventionPlugin : Plugin<Project> {
     override fun apply(target: Project) = with(target) {
         val localProperties = Properties()
@@ -42,7 +46,6 @@ class ApiKeyProviderConventionPlugin : Plugin<Project> {
              *     }
              * }
              */
-
         }
     }
 }

--- a/build-logic/convention/src/main/kotlin/ApiKeyProviderConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/ApiKeyProviderConventionPlugin.kt
@@ -1,0 +1,29 @@
+import com.android.build.gradle.internal.dsl.BaseAppModuleExtension
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.configure
+import java.util.Properties
+
+class ApiKeyProviderConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) = with(target) {
+        val localProperties = Properties()
+        val localPropertiesFile = rootProject.file("local.properties") // it's ignored by git
+        if (localPropertiesFile.exists() && localPropertiesFile.isFile) {
+            localPropertiesFile.inputStream().use { input ->
+                localProperties.load(input)
+            }
+        }
+
+        val doodleApiUrl = checkNotNull(
+            localProperties.getProperty("doodle.apiurl") ?: System.getenv("DOODLE_API_URL")
+        )
+        val doodleApiKey = checkNotNull(
+            localProperties.getProperty("doodle.apikey") ?: System.getenv("DOODLE_API_KEY")
+        )
+
+        extensions.configure<BaseAppModuleExtension> {
+            defaultConfig.buildConfigField("String", "DOODLE_API_URL", "\"$doodleApiUrl\"")
+            defaultConfig.buildConfigField("String", "DOODLE_API_KEY", "\"$doodleApiKey\"")
+        }
+    }
+}

--- a/build-logic/convention/src/main/kotlin/dev/enesky/build_logic/convention/AndroidApplication.kt
+++ b/build-logic/convention/src/main/kotlin/dev/enesky/build_logic/convention/AndroidApplication.kt
@@ -6,6 +6,7 @@ import com.android.build.api.dsl.ApplicationExtension
 /**
  * Created by Enes Kamil YILMAZ on 03/11/2023
  */
+
 internal fun ApplicationExtension.getBuildTypes() =
     buildTypes {
         debug {
@@ -25,7 +26,7 @@ internal fun ApplicationExtension.getBuildTypes() =
             )
 
             // Specified Build Configs
-            buildConfigField("String", "example", "\"Lorem Ipsum but release\"")
+            buildConfigField("String", "example", "Lorem Ipsum but release")
             buildConfigField("boolean", "logEnabled", "false")
         }
     }
@@ -47,22 +48,25 @@ internal fun ApplicationExtension.getProductFlavors() {
             dimension = "mode"
             applicationIdSuffix = ".trial"
             versionNameSuffix = "-trial"
+
+            // Specified Res Values
             resValue("string", "app_name_flavor", "Doodle Trial")
         }
         create("premium") {
             dimension = "mode"
             applicationIdSuffix = ".premium"
             versionNameSuffix = "-premium"
+
+            // Specified Res Values
             resValue("string", "app_name_flavor", "Doodle Premium")
 
             // Specified Build Configs
-            buildConfigField("String", "BASE_URL", "\"https://api.jikan.moe/v4/\"")
+            buildConfigField("String", "example", "Lorem Ipsum but premium")
         }
     }
 }
 
 internal fun ApplicationDefaultConfig.getGeneralBuildConfigs() {
     resValue("string", "app_name_flavor", "Doodle")
-    buildConfigField("String", "BASE_URL", "\"https://api.jikan.moe/v4/\"")
-    buildConfigField("String", "example", "\"Lorem Ipsum\"")
+    buildConfigField("String", "example", "Lorem Ipsum")
 }

--- a/build-logic/convention/src/main/kotlin/dev/enesky/build_logic/convention/Extensions.kt
+++ b/build-logic/convention/src/main/kotlin/dev/enesky/build_logic/convention/Extensions.kt
@@ -1,56 +1,13 @@
 package dev.enesky.build_logic.convention
 
 import com.android.build.api.dsl.CommonExtension
-import com.android.build.gradle.internal.dsl.BaseAppModuleExtension
-import com.android.build.gradle.internal.dsl.SigningConfig
 import org.gradle.accessors.dm.LibrariesForLibs
 import org.gradle.api.Project
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.kotlin.dsl.the
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmOptions
-import java.util.Properties
 
 internal val Project.libs get() = the<LibrariesForLibs>()
 
 internal fun CommonExtension<*, *, *, *, *>.kotlinOptions(block: KotlinJvmOptions.() -> Unit) =
     (this as ExtensionAware).extensions.configure("kotlinOptions", block)
-/**
- * Other option for kotlinOptions
- *
- * internal fun Project.configureKotlin() {
- *     tasks.withType<KotlinCompile>().configureEach {
- *         kotlinOptions {
- *             jvmTarget = JavaVersion.VERSION_17.toString()
- *         }
- *     }
- * }
- */
-
-internal fun BaseAppModuleExtension.createSigningConfigFromProperties(
-    target: Project,
-    name: String,
-    properties: Properties
-): SigningConfig? {
-
-    /**
-     *                 !!! IMPORTANT !!!
-     * Change storeFile path if Doodle goes to any market
-     **/
-    val keystore = mapOf(
-        "storeFile" to properties.getProperty("storeFile").toString(),
-        "storePassword" to properties.getProperty("storePassword").toString(),
-        "keyAlias" to properties.getProperty("keyAlias").toString(),
-        "keyPassword" to properties.getProperty("keyPassword").toString(),
-    )
-
-    if (keystore.values.any(String::isNullOrBlank)) return null
-
-    return signingConfigs.create(name) {
-        keyAlias = keystore.getValue("keyAlias")
-        keyPassword = keystore.getValue("keyPassword")
-        storeFile = target.file(keystore.getValue("storeFile"))
-        storePassword = keystore.getValue("storePassword")
-        enableV1Signing = true //Jar Signature
-        enableV2Signing = true // Full APK Signature
-    }
-}

--- a/build-logic/convention/src/main/kotlin/dev/enesky/build_logic/convention/SigningConfig.kt
+++ b/build-logic/convention/src/main/kotlin/dev/enesky/build_logic/convention/SigningConfig.kt
@@ -1,0 +1,39 @@
+package dev.enesky.build_logic.convention
+
+import com.android.build.gradle.internal.dsl.BaseAppModuleExtension
+import com.android.build.gradle.internal.dsl.SigningConfig
+import org.gradle.api.Project
+import java.util.Properties
+
+/**
+ * Created by Enes Kamil YILMAZ on 05/11/2023
+ */
+
+internal fun BaseAppModuleExtension.createSigningConfigFromProperties(
+    target: Project,
+    name: String,
+    properties: Properties
+): SigningConfig? {
+
+    /**
+     *                 !!! IMPORTANT !!!
+     * Change storeFile path if Doodle goes to any market
+     **/
+    val keystore = mapOf(
+        "storeFile" to properties.getProperty("storeFile").toString(),
+        "storePassword" to properties.getProperty("storePassword").toString(),
+        "keyAlias" to properties.getProperty("keyAlias").toString(),
+        "keyPassword" to properties.getProperty("keyPassword").toString(),
+    )
+
+    if (keystore.values.any(String::isNullOrBlank)) return null
+
+    return signingConfigs.create(name) {
+        keyAlias = keystore.getValue("keyAlias")
+        keyPassword = keystore.getValue("keyPassword")
+        storeFile = target.file(keystore.getValue("storeFile"))
+        storePassword = keystore.getValue("storePassword")
+        enableV1Signing = true //Jar Signature
+        enableV2Signing = true // Full APK Signature
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -60,6 +60,7 @@ doodle-android-library-compose        = { id= "doodle.android.library.compose", 
 doodle-android-library-jacoco         = { id= "doodle.android.library.jacoco", version= "unspecified" }
 doodle-android-test                   = { id= "doodle.android.test", version= "unspecified" }
 doodle-detekt-library                 = { id= "doodle.detekt.library", version= "unspecified" }
+doodle-api-key-provider               = { id= "doodle.api.key.provider", version= "unspecified" }
 
 [libraries]
 core-ktx                              = { module= "androidx.core:core-ktx", version.ref= "core-ktx" }


### PR DESCRIPTION
## <sup><sup>&#x1F534; [Mandatory]</sup></sup> What's the change?
- Created new convention plugin for getting api related improtant informations from local.properties
- And it's used in signing config plugin in order to specially use it in app/build.gradle.kts 
- Readme updated

## <sup><sup>&#x1F534; [Mandatory]</sup></sup> Why do we need this change?
- Api related informations shouldn't be inside a repo because it might stolen by others
- It should be private for app owner
   
## Related issues/PRs/Jira ticket links
- X
   
## <sup><sup>&#x1F534; [Mandatory if it's UI related]</sup></sup> Screenshots
- X