### PR TITLE
feat: Git Hooks Convention Plugin

### DIFF
--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -86,6 +86,10 @@ gradlePlugin {
             id = libs.plugins.doodle.api.key.provider.get().pluginId
             implementationClass = "ApiKeyProviderConventionPlugin"
         }
+        register("gitHooks") {
+            id = libs.plugins.doodle.git.hooks.get().pluginId
+            implementationClass = "GitHooksConventionPlugin"
+        }
     }
 }
 

--- a/build-logic/convention/src/main/kotlin/GitHooksConventionPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/GitHooksConventionPlugin.kt
@@ -1,0 +1,27 @@
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.tasks.Delete
+import org.gradle.kotlin.dsl.apply
+import org.gradle.kotlin.dsl.register
+
+/**
+ * Configure Git Hooks
+ * -> Only for project/build.gradle.kts <-
+ */
+
+class GitHooksConventionPlugin : Plugin<Project> {
+    override fun apply(target: Project) = with(target) {
+
+        apply(from = "git-hooks/githooks.gradle")
+
+        tasks.register("clean", Delete::class) {
+            delete(rootProject.layout.buildDirectory)
+        }
+
+        afterEvaluate {
+            tasks.named("clean") {
+                dependsOn(":installGitHooks")
+            }
+        }
+    }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,19 +12,5 @@ plugins {
 
     // Convention Plugins
     id(libs.plugins.doodle.detekt.library.get().pluginId)
-}
-
-/**
- * Git Hooks Related
- **/
-apply(from = "git-hooks/githooks.gradle")
-
-tasks.register("clean", Delete::class) {
-    delete(rootProject.layout.buildDirectory)
-}
-
-afterEvaluate {
-    tasks.named("clean") {
-        dependsOn(":installGitHooks")
-    }
+    id(libs.plugins.doodle.git.hooks.get().pluginId)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,7 +6,7 @@ target-sdk = "34"
 compose-compiler = "1.5.3"
 
 # Plugin Versions
-gradle-plugin                         = "8.3.0-alpha11"
+gradle-plugin                         = "8.3.0-alpha12"
 kotlin-plugin                         = "1.9.10"
 ksp-plugin                            = "1.9.10-1.0.13"
 google-services-plugin                = "4.4.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -61,6 +61,7 @@ doodle-android-library-jacoco         = { id= "doodle.android.library.jacoco", v
 doodle-android-test                   = { id= "doodle.android.test", version= "unspecified" }
 doodle-detekt-library                 = { id= "doodle.detekt.library", version= "unspecified" }
 doodle-api-key-provider               = { id= "doodle.api.key.provider", version= "unspecified" }
+doodle-git-hooks                      = { id= "doodle.git.hooks", version= "unspecified" }
 
 [libraries]
 core-ktx                              = { module= "androidx.core:core-ktx", version.ref= "core-ktx" }


### PR DESCRIPTION
## <sup><sup>&#x1F534; [Mandatory]</sup></sup> What's the change?
-  Added GitHooksConventionPlugin and git hook related configurations at project/build.gradle.kts moved there
-  Gradle plugin  updated to "8.3.0-alpha12"

## <sup><sup>&#x1F534; [Mandatory]</sup></sup> Why do we need this change?
-   To clear all configurations from build.gradle files and use convention plugin more :)