### PR TITLE
feat: Multi module setup is completed

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -24,4 +24,16 @@ dependencies {
     implementation(libs.bundles.network)
     implementation(libs.bundles.third.party.libraries)
     implementation(libs.bundles.androidx.libraries)
+
+    // Module Implementations
+    implementation(projects.core.common)
+    implementation(projects.core.data)
+    implementation(projects.core.domain)
+    implementation(projects.core.network)
+    implementation(projects.core.navigation)
+    implementation(projects.core.ui)
+    implementation(projects.feature.login)
+    implementation(projects.feature.main)
+    implementation(projects.feature.details)
+    implementation(projects.feature.settings)
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -18,6 +18,12 @@ dependencyResolutionManagement {
 
 rootProject.name = "Doodle"
 
+/**
+ * Enables to use modules with type-safe accessors
+ * ex. implementation(project(":core:common")) -> implementation(projects.core.common)
+ **/
+enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
+
 include(":app")
 include(
     ":core:common",


### PR DESCRIPTION
## <sup><sup>&#x1F534; [Mandatory]</sup></sup> What's the change?
- Added type safe project accessor enabler to project/settings.gradle
- All modules added to app module

## <sup><sup>&#x1F534; [Mandatory]</sup></sup> Why do we need this change?
- To be able to use modules in build.gradle files with type safe accessors