### PR TITLE
feat: Detekt action added to GitHub

### DIFF
--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -29,15 +29,15 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v3
 
       - name: Setup JDK 17
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 17
 
       - name: Cache
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ~/${{ env.WORKING_DIR }}/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}

--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -35,6 +35,7 @@ jobs:
         uses: actions/setup-java@v3.13.0
         with:
           java-version: 17
+          distribution: 'adopt'
 
       - name: Cache
         uses: actions/cache@v3.3.2

--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -1,0 +1,106 @@
+# This workflow performs a static analysis of your Kotlin source code using
+# Detekt.
+#
+# Scans are triggered:
+# 1. On every push to default and protected branches
+# 2. On every Pull Request targeting the default branch
+# 3. Manually, on demand, via the "workflow_dispatch" event
+
+name: Scan with Detekt
+
+on:
+  # Triggers the workflow on push or pull request events but only for default and protected branches
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+env:
+  # Release tag associated with version of Detekt to be installed
+  DETEKT_RELEASE_TAG: v1.23.3
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "scan"
+  scan:
+    name: Scan
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v3
+
+    # Gets the download URL associated with the $DETEKT_RELEASE_TAG
+    - name: Get Detekt download URL
+      id: detekt_info
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        gh api graphql --field tagName=$DETEKT_RELEASE_TAG --raw-field query='
+          query getReleaseAssetDownloadUrl($tagName: String!) {
+            repository(name: "detekt", owner: "detekt") {
+              release(tagName: $tagName) {
+                releaseAssets(name: "detekt", first: 1) {
+                  nodes {
+                    downloadUrl
+                  }
+                }
+                tagCommit {
+                  oid
+                }
+              }
+            }
+          }
+        ' 1> gh_response.json
+
+        DETEKT_RELEASE_SHA=$(jq --raw-output '.data.repository.release.releaseAssets.tagCommit.oid' gh_response.json)
+        if [ $DETEKT_RELEASE_SHA != "37f0a1d006977512f1f216506cd695039607c3e5" ]; then
+          echo "Release tag doesn't match expected commit SHA"
+          exit 1
+        fi
+
+        DETEKT_DOWNLOAD_URL=$(jq --raw-output '.data.repository.release.releaseAssets.nodes[0].downloadUrl' gh_response.json)
+        echo "download_url=$DETEKT_DOWNLOAD_URL" >> $GITHUB_OUTPUT
+
+    # Sets up the detekt cli
+    - name: Setup Detekt
+      run: |
+        dest=$( mktemp -d )
+        curl --request GET \
+          --url ${{ steps.detekt_info.outputs.download_url }} \
+          --silent \
+          --location \
+          --output $dest/detekt
+        chmod a+x $dest/detekt
+        echo $dest >> $GITHUB_PATH
+
+    # Performs static analysis using Detekt
+    - name: Run Detekt
+      continue-on-error: true
+      run: |
+        detekt --input ${{ github.workspace }} --report sarif:${{ github.workspace }}/detekt.sarif.json
+
+    # Modifies the SARIF output produced by Detekt so that absolute URIs are relative
+    # This is so we can easily map results onto their source files
+    # This can be removed once relative URI support lands in Detekt: https://git.io/JLBbA
+    - name: Make artifact location URIs relative
+      continue-on-error: true
+      run: |
+        echo "$(
+          jq \
+            --arg github_workspace ${{ github.workspace }} \
+            '. | ( .runs[].results[].locations[].physicalLocation.artifactLocation.uri |= if test($github_workspace) then .[($github_workspace | length | . + 1):] else . end )' \
+            ${{ github.workspace }}/detekt.sarif.json
+        )" > ${{ github.workspace }}/detekt.sarif.json
+
+    # Uploads results to GitHub repository using the upload-sarif action
+    - uses: github/codeql-action/upload-sarif@v2
+      with:
+        # Path to SARIF file relative to the root of the repository
+        sarif_file: ${{ github.workspace }}/detekt.sarif.json
+        checkout_path: ${{ github.workspace }}

--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -18,10 +18,6 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-env:
-  # Release tag associated with version of Detekt to be installed
-  DETEKT_RELEASE_TAG: v1.23.3
-
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "scan"
@@ -32,75 +28,22 @@ jobs:
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-    - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v1
 
-    # Gets the download URL associated with the $DETEKT_RELEASE_TAG
-    - name: Get Detekt download URL
-      id: detekt_info
-      env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: |
-        gh api graphql --field tagName=$DETEKT_RELEASE_TAG --raw-field query='
-          query getReleaseAssetDownloadUrl($tagName: String!) {
-            repository(name: "detekt", owner: "detekt") {
-              release(tagName: $tagName) {
-                releaseAssets(name: "detekt", first: 1) {
-                  nodes {
-                    downloadUrl
-                  }
-                }
-                tagCommit {
-                  oid
-                }
-              }
-            }
-          }
-        ' 1> gh_response.json
+      - name: Setup JDK 17
+        uses: actions/setup-java@v1
+        with:
+          java-version: 17
 
-        DETEKT_RELEASE_SHA=$(jq --raw-output '.data.repository.release.releaseAssets.tagCommit.oid' gh_response.json)
-        if [ $DETEKT_RELEASE_SHA != "37f0a1d006977512f1f216506cd695039607c3e5" ]; then
-          echo "Release tag doesn't match expected commit SHA"
-          exit 1
-        fi
+      - name: Cache
+        uses: actions/cache@v1
+        with:
+          path: ~/${{ env.WORKING_DIR }}/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
 
-        DETEKT_DOWNLOAD_URL=$(jq --raw-output '.data.repository.release.releaseAssets.nodes[0].downloadUrl' gh_response.json)
-        echo "download_url=$DETEKT_DOWNLOAD_URL" >> $GITHUB_OUTPUT
-
-    # Sets up the detekt cli
-    - name: Setup Detekt
-      run: |
-        dest=$( mktemp -d )
-        curl --request GET \
-          --url ${{ steps.detekt_info.outputs.download_url }} \
-          --silent \
-          --location \
-          --output $dest/detekt
-        chmod a+x $dest/detekt
-        echo $dest >> $GITHUB_PATH
-
-    # Performs static analysis using Detekt
-    - name: Run Detekt
-      continue-on-error: true
-      run: |
-        detekt --input ${{ github.workspace }} --report sarif:${{ github.workspace }}/detekt.sarif.json
-
-    # Modifies the SARIF output produced by Detekt so that absolute URIs are relative
-    # This is so we can easily map results onto their source files
-    # This can be removed once relative URI support lands in Detekt: https://git.io/JLBbA
-    - name: Make artifact location URIs relative
-      continue-on-error: true
-      run: |
-        echo "$(
-          jq \
-            --arg github_workspace ${{ github.workspace }} \
-            '. | ( .runs[].results[].locations[].physicalLocation.artifactLocation.uri |= if test($github_workspace) then .[($github_workspace | length | . + 1):] else . end )' \
-            ${{ github.workspace }}/detekt.sarif.json
-        )" > ${{ github.workspace }}/detekt.sarif.json
-
-    # Uploads results to GitHub repository using the upload-sarif action
-    - uses: github/codeql-action/upload-sarif@v2
-      with:
-        # Path to SARIF file relative to the root of the repository
-        sarif_file: ${{ github.workspace }}/detekt.sarif.json
-        checkout_path: ${{ github.workspace }}
+      - name: Run Detekt
+        working-directory: ${{ env.WORKING_DIR }}
+        run: ./gradlew detektAll

--- a/.github/workflows/detekt.yml
+++ b/.github/workflows/detekt.yml
@@ -29,15 +29,15 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4.1.1
 
       - name: Setup JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v3.13.0
         with:
           java-version: 17
 
       - name: Cache
-        uses: actions/cache@v3
+        uses: actions/cache@v3.3.2
         with:
           path: ~/${{ env.WORKING_DIR }}/.gradle/caches
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}


### PR DESCRIPTION
## <sup><sup>&#x1F534; [Mandatory]</sup></sup> What's the change?
- Detekt action is added to GitHub repo
- When a user creates a PR or pushes a commit to 'main' branch it'll automaticly runs the Scan with Detekt action
- Successfully completed -> https://github.com/enesky/Doodle/actions/runs/6811611325

## <sup><sup>&#x1F534; [Mandatory]</sup></sup> Why do we need this change?
- To be able to check detekt status remotely
- To learn about GitHub Actions :)

## <sup><sup>&#x1F534; [Mandatory if it's UI related]</sup></sup> Screenshots
<img width="1034" alt="Screenshot 2023-11-09 at 15 21 51" src="https://github.com/enesky/Doodle/assets/25669076/9559bbb1-bf57-4aab-9718-9c769ac961e3">